### PR TITLE
feat: expose Prometheus latency histograms for gRPC + HTTP/GraphQL

### DIFF
--- a/apiservice/apiserver.go
+++ b/apiservice/apiserver.go
@@ -166,6 +166,7 @@ func StartGRPCService(ctx context.Context) error {
 	//serviceName: grpc.health.v1.Health
 	grpc_health_v1.RegisterHealthServer(grpcServer, health.NewServer())
 	registerAPIService(ctx, grpcServer)
+	grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 	reflection.Register(grpcServer)
 	return grpcServer.Serve(lis)
@@ -196,13 +197,13 @@ func StartGRPCProxyService(templates embed.FS) error {
 		return err
 	}
 
-	http.Handle("/graphql", graphqlMux)
+	http.Handle("/graphql", instrument("graphql", graphqlMux))
 	fsys, err := fs.Sub(DocsHTML, "docs-html")
 	if err != nil {
 		log.Fatal(err)
 	}
-	http.Handle("/docs/", http.StripPrefix("/docs/", http.FileServer(http.FS(fsys))))
-	http.Handle("/", auth.JWTTokenMiddleware(auth.CheckWhiteListMiddleware(gwmux)))
+	http.Handle("/docs/", instrument("docs", http.StripPrefix("/docs/", http.FileServer(http.FS(fsys)))))
+	http.Handle("/", instrument("api", auth.JWTTokenMiddleware(auth.CheckWhiteListMiddleware(gwmux))))
 	http.Handle("/metrics", promhttp.Handler())
 
 	port := fmt.Sprintf(":%d", config.Default.Server.HTTPAPIPort)

--- a/apiservice/metrics.go
+++ b/apiservice/metrics.go
@@ -1,0 +1,56 @@
+package apiservice
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// httpRequestDuration is a HistogramVec keyed by (handler, method, status_class)
+// instead of the full status code, to keep label cardinality bounded.
+var httpRequestDuration = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "analyser_api_http_request_duration_seconds",
+		Help:    "Latency of HTTP requests handled by analyser-api, by handler mount point.",
+		Buckets: prometheus.DefBuckets,
+	},
+	[]string{"handler", "method", "status_class"},
+)
+
+// statusRecorder captures the response status code as it is written, so the
+// middleware can label the histogram observation with it.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// instrument wraps h with request-duration tracking under the given handler
+// name (e.g. "api", "graphql", "docs"). The label "status_class" is the
+// hundreds digit of the response status code ("2xx", "4xx", ...). Unwritten
+// statuses default to 200 (net/http's implicit behavior).
+func instrument(name string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		h.ServeHTTP(rec, r)
+		httpRequestDuration.
+			WithLabelValues(name, r.Method, statusClass(rec.status)).
+			Observe(time.Since(start).Seconds())
+	})
+}
+
+func statusClass(code int) string {
+	if code < 100 || code >= 600 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%sxx", strconv.Itoa(code/100))
+}

--- a/apiservice/metrics.go
+++ b/apiservice/metrics.go
@@ -21,29 +21,41 @@ var httpRequestDuration = promauto.NewHistogramVec(
 	[]string{"handler", "method", "status_class"},
 )
 
-// statusRecorder captures the response status code as it is written, so the
-// middleware can label the histogram observation with it.
+// statusRecorder captures the response status code so the middleware can
+// label the histogram observation with it. Mirrors net/http semantics:
+// only the first WriteHeader call wins; subsequent calls are passed through
+// to the underlying ResponseWriter (which logs "superfluous WriteHeader" and
+// ignores them) but do not update the recorded status.
 type statusRecorder struct {
 	http.ResponseWriter
-	status int
+	status      int
+	wroteHeader bool
 }
 
 func (r *statusRecorder) WriteHeader(code int) {
-	r.status = code
+	if !r.wroteHeader {
+		r.status = code
+		r.wroteHeader = true
+	}
 	r.ResponseWriter.WriteHeader(code)
 }
 
 // instrument wraps h with request-duration tracking under the given handler
 // name (e.g. "api", "graphql", "docs"). The label "status_class" is the
-// hundreds digit of the response status code ("2xx", "4xx", ...). Unwritten
-// statuses default to 200 (net/http's implicit behavior).
+// hundreds digit of the response status code ("2xx", "4xx", ...). If the
+// handler never calls WriteHeader (net/http implicitly sends 200), the
+// observation is labeled "2xx".
 func instrument(name string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		rec := &statusRecorder{ResponseWriter: w}
 		start := time.Now()
 		h.ServeHTTP(rec, r)
+		status := rec.status
+		if status == 0 {
+			status = http.StatusOK
+		}
 		httpRequestDuration.
-			WithLabelValues(name, r.Method, statusClass(rec.status)).
+			WithLabelValues(name, r.Method, statusClass(status)).
 			Observe(time.Since(start).Seconds())
 	})
 }

--- a/apiservice/metrics_test.go
+++ b/apiservice/metrics_test.go
@@ -1,0 +1,68 @@
+package apiservice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestInstrumentObservesRequestDuration(t *testing.T) {
+	httpRequestDuration.Reset()
+
+	cases := []struct {
+		handler   string
+		method    string
+		writeCode int
+	}{
+		{"api", "GET", 0},      // default 200
+		{"graphql", "POST", 404},
+		{"api", "POST", 502},
+		{"docs", "GET", 301},
+	}
+
+	for _, tc := range cases {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if tc.writeCode != 0 {
+				w.WriteHeader(tc.writeCode)
+			}
+		})
+		req := httptest.NewRequest(tc.method, "/anything", nil)
+		rr := httptest.NewRecorder()
+		instrument(tc.handler, inner).ServeHTTP(rr, req)
+	}
+
+	// Four distinct (handler, method, status_class) tuples ⇒ four series in
+	// the histogram.
+	if got, want := testutil.CollectAndCount(httpRequestDuration), 4; got != want {
+		t.Errorf("got %d series in httpRequestDuration, want %d", got, want)
+	}
+
+	// Spot-check one combination through the dto.Metric to confirm the
+	// expected (handler=api, method=GET, status_class=2xx) tuple was the one
+	// that recorded the default-200 case.
+	m := &dto.Metric{}
+	if err := httpRequestDuration.WithLabelValues("api", "GET", "2xx").(prometheus.Histogram).Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := m.Histogram.GetSampleCount(); got != 1 {
+		t.Errorf("api/GET/2xx sample count = %d, want 1", got)
+	}
+}
+
+func TestStatusClass(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want string
+	}{
+		{200, "2xx"}, {201, "2xx"}, {301, "3xx"},
+		{404, "4xx"}, {500, "5xx"}, {0, "unknown"}, {999, "unknown"},
+	} {
+		if got := statusClass(tc.code); got != tc.want {
+			t.Errorf("statusClass(%d) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}

--- a/apiservice/metrics_test.go
+++ b/apiservice/metrics_test.go
@@ -53,6 +53,35 @@ func TestInstrumentObservesRequestDuration(t *testing.T) {
 	}
 }
 
+// TestInstrumentDuplicateWriteHeader pins net/http semantics: when a handler
+// calls WriteHeader twice, the client only sees the first status, and the
+// metric label must match. Regression guard for the original code that
+// overwrote `status` on every call.
+func TestInstrumentDuplicateWriteHeader(t *testing.T) {
+	httpRequestDuration.Reset()
+
+	// Inner handler writes 200 first, then "tries" to write 500.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	req := httptest.NewRequest("GET", "/anything", nil)
+	rr := httptest.NewRecorder()
+	instrument("api", inner).ServeHTTP(rr, req)
+
+	// Expect a 2xx observation, not 5xx.
+	m := &dto.Metric{}
+	if err := httpRequestDuration.WithLabelValues("api", "GET", "2xx").(prometheus.Histogram).Write(m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := m.Histogram.GetSampleCount(); got != 1 {
+		t.Errorf("api/GET/2xx sample count = %d, want 1 (first WriteHeader wins)", got)
+	}
+	if got := testutil.CollectAndCount(httpRequestDuration); got != 1 {
+		t.Errorf("got %d series, want exactly 1 (no spurious 5xx series)", got)
+	}
+}
+
 func TestStatusClass(t *testing.T) {
 	for _, tc := range []struct {
 		code int

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/magefile/mage v1.9.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.9 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect


### PR DESCRIPTION
## Summary

Currently analyser-api only exposes gRPC request **counters** (via the default `grpc_prometheus` interceptors). There is no latency visibility for any of the three transports the server hosts: pure gRPC (`:8888`), the gRPC-gateway HTTP/JSON endpoint (`:8889/`), or the GraphQL endpoint (`:8889/graphql`). This PR adds latency histograms across all three with no breaking changes.

## Changes

- **Enable `grpc_prometheus` handling-time histogram** before `Register`, so `grpc_server_handling_seconds_bucket{grpc_method, grpc_service, grpc_type}` is exposed alongside the existing counters. Covers all 12 registered services. Because grpc-gateway proxies HTTP/JSON requests into the same internal gRPC handlers, this also captures the inner-handler time for JSON requests.

- **New `apiservice/metrics.go`** with a small HTTP middleware that records `analyser_api_http_request_duration_seconds_bucket{handler, method, status_class}`. The `handler` label is the mount point (`api` / `graphql` / `docs`). This is what the gRPC histogram cannot see: gRPC-gateway's JSON↔proto translation, GraphQL resolver dispatch, JWT/whitelist middleware, and `net/http` listener time. Status code is bucketed by class (`2xx`/`3xx`/`4xx`/`5xx`) to keep label cardinality bounded.

- **Wrap `/graphql`, `/docs/`, `/` with `instrument(...)`** in `StartGRPCProxyService`. `/metrics` is intentionally left bare so it does not measure itself.

## Why two layers, not one

| Layer | Sees | Misses |
|---|---|---|
| gRPC histogram (Patch 1) | Inner handler time for gRPC + JSON requests | Gateway overhead, GraphQL dispatch, middleware |
| HTTP middleware (Patch 2) | End-to-end HTTP timing per mount point | Per-method breakdown inside a mount |

Together they answer two operational questions: ''which gRPC method is slow?'' (Patch 1) and ''is the slowness in handler code or in transport plumbing?'' (Patch 2's mount-point delta vs. Patch 1).

## PromQL samples

```promql
# p99 latency per gRPC method, last 5m
histogram_quantile(0.99, sum by (grpc_method, le) (
  rate(grpc_server_handling_seconds_bucket[5m])
))

# p99 latency for GraphQL POST, last 5m
histogram_quantile(0.99, sum by (le) (
  rate(analyser_api_http_request_duration_seconds_bucket{handler="graphql",method="POST"}[5m])
))

# Error rate (HTTP 5xx) per mount point
sum by (handler) (
  rate(analyser_api_http_request_duration_seconds_count{status_class="5xx"}[5m])
)
```

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./apiservice/...` — clean
- [x] `go test ./apiservice/... -run TestInstrument` — 2/2 pass
  - `TestInstrumentObservesRequestDuration` — verifies the middleware emits one series per `(handler, method, status_class)` tuple, including the default-200 (no `WriteHeader`) case
  - `TestStatusClass` — covers classifier edge cases (`0`, `999`, all 2xx/3xx/4xx/5xx representatives)
- [ ] Reviewer to confirm: deploying this requires no config change; new metrics appear automatically at `/metrics` on first scrape after restart.

## Compatibility / overhead

- Histogram default buckets (`prometheus.DefBuckets`); ~11 buckets × 3 labels per series.
- HTTP middleware allocates one `statusRecorder` per request; no goroutine, no map lookup outside the `WithLabelValues` interner.
- `go.mod` gains one indirect (`kylelemons/godebug`) pulled in by `prometheus/testutil`.