### PR TITLE
fix(actions): scan block.timestamp as time.Time in GetAllActionsByAddress

### DIFF
--- a/apiservice/actions_service.go
+++ b/apiservice/actions_service.go
@@ -3,6 +3,7 @@ package apiservice
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-analyser-api/api"
@@ -129,7 +130,8 @@ func (s *ActionsService) GetAllActionsByAddress(ctx context.Context, req *api.Ac
 	}
 	defer rows.Close()
 	var actHash, sender, recipient, amount, actType, rtype string
-	var blkHeight, timestamp uint64
+	var blkHeight uint64
+	var timestamp time.Time
 	for rows.Next() {
 		if err := rows.Scan(&blkHeight, &actHash, &amount, &sender, &recipient, &rtype, &actType, &timestamp); err != nil {
 			return nil, err
@@ -145,7 +147,7 @@ func (s *ActionsService) GetAllActionsByAddress(ctx context.Context, req *api.Ac
 		}
 		resp.Results = append(resp.Results, &api.AllActionsByAddressResult{
 			ActHash:    actHash,
-			TimeStamp:  timestamp,
+			TimeStamp:  uint64(timestamp.Unix()),
 			ActType:    actType,
 			BlkHeight:  blkHeight,
 			Sender:     sender,


### PR DESCRIPTION
## Summary
- `GetAllActionsByAddress` was scanning the `block.timestamp` subquery result into a `uint64`, but the column is a Postgres `TIMESTAMP` (Go `time.Time`), so every call to `/api.ActionsService.GetAllActionsByAddress` returned `HTTP 500: sql: Scan error on column index 7 ... converting driver.Value type time.Time to a uint64`.
- Scan into `time.Time` and convert via `.Unix()` to match the proto field type (`uint64` seconds).

## Reproduction
```
GET https://gateway1.iotex.io/transaction/getAllTransactionsWithAssetsByAccount?address=0x1745a52aA2939422D603FB5035ECb0db686a647c&pageSize=50
→ analyser-api /api.ActionsService.GetAllActionsByAddress -> HTTP 500
  sql: Scan error on column index 7, name "timestamp":
  converting driver.Value type time.Time ("2026-06-02 11:21:00 +0000 UTC") to a uint64
```

## Test plan
- [ ] `go build ./...` passes
- [ ] Hit `getAllTransactionsWithAssetsByAccount` against a deployed analyser-api and confirm 200 + sensible `timeStamp` values (Unix seconds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)