### PR TITLE
perf(actions): use Postgres reltuples estimate for GetActionCount (5s → <1ms)

### DIFF
--- a/common/actions/action.go
+++ b/common/actions/action.go
@@ -204,6 +204,19 @@ func GetActionCountByType(ctx context.Context, typ string) (int64, error) {
 func GetActionCount() (int64, error) {
 	var count int64
 	db := db.DB()
+	// On Postgres, summing pg_class.reltuples across the partition children returns in <1ms
+	// vs ~5s for COUNT(*) on the 300M+ row block_action_partition. Drift is bounded by
+	// autovacuum cadence (typically <1%), acceptable for the /txs page total counter.
+	if db.Dialector.Name() == "postgres" {
+		err := db.Raw(`SELECT COALESCE(sum(c.reltuples), 0)::bigint
+			FROM pg_inherits i
+			JOIN pg_class c ON c.oid = i.inhrelid
+			WHERE i.inhparent = 'block_action_partition'::regclass`).Scan(&count).Error
+		if err == nil {
+			return count, nil
+		}
+		// Fall back to the exact count on error (e.g. partition parent missing in tests).
+	}
 	if err := db.Table("block_action_partition").Count(&count).Error; err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Problem

iotexscan-v4's `/txs` transaction list page top counter ("Total transactions: …") calls `ActionService.ActionList` with no filter to read `count`. That dispatches to `actions.GetActionCount()` (`common/actions/action.go:204`), which issues:

```sql
SELECT count(*) FROM block_action_partition
```

On live mainnet `block_action_partition` is **50 partitions / 312M rows / 91 GB**. Measured on a warm buffer pool:

```
 count
-----------
 312171847
Time: 4978.764 ms
```

Cold-cache times are much worse. v4 wraps the call in a 15s in-memory cache but every cache-miss render blocks ~5s on this query, and the `/txs` page can't render its pagination footer until it returns.

## Fix

On Postgres, sum `pg_class.reltuples` across the partition children. Same number, **<1ms**:

```sql
SELECT COALESCE(sum(c.reltuples), 0)::bigint
FROM pg_inherits i
JOIN pg_class c ON c.oid = i.inhrelid
WHERE i.inhparent = 'block_action_partition'::regclass;
```

Tested live on bm5 mainnet:

| | rows | latency |
|---|---:|---:|
| `SELECT count(*) FROM block_action_partition` | 312,171,847 | 4978 ms |
| `sum(pg_class.reltuples) over partitions` | 311,261,696 | <1 ms |

**Drift: 0.3%**, bounded by autovacuum cadence — imperceptible on a paginated-25-per-page list page total counter.

## Compatibility

Repo CLAUDE.md requires queries to be compatible with PG / MySQL / SQLite. This change is **PG-only fast path with fallback**:

- `db.Dialector.Name() == "postgres"`: try the estimate; on error fall back to exact `COUNT(*)`
- MySQL / SQLite: unchanged code path

## Scope

Only `GetActionCount()` is changed in this PR. The WHERE-filtered variants need different approaches:

- `GetActionCountByType(typ)` — has a pre-existing `//TODO: fix the slow query` comment; per-type counter table or `pg_stats_ext` is a separate, larger change
- `GetActionCountFromHeight(startBh)` / `GetActionCountByHeight(height)` — could use index-only scans, but lower frequency and out of scope here

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./common/actions/...` clean (no new findings; pre-existing lints unrelated)
- [x] Live SQL probed on bm5 mainnet PG17 — both queries return; estimate drift 0.3%
- [ ] Deploy + browser test `/txs` page on iotexscan.io after merge