### PR TITLE
fix: redact DB password in startup log + add SkipAutoMigrate flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -54,6 +55,10 @@ type (
 		Password string `yaml:"password"  env:"DB_PASSWORD"`
 		Name     string `yaml:"name"  env:"DB_NAME"`
 		Debug    bool   `yaml:"debug"  env:"DB_DEBUG"`
+		// SkipAutoMigrate disables the GORM AutoMigrate run at startup. Required
+		// when pointing the API at a read-only PG standby — AutoMigrate issues
+		// DDL and a standby rejects writes with SQLSTATE 25006.
+		SkipAutoMigrate bool `yaml:"skipAutoMigrate"  env:"DB_SKIP_AUTO_MIGRATE"`
 	}
 	Genesis struct {
 		VoteWeightCalConsts genesis.VoteWeightCalConsts `yaml:"voteWeightCalConsts"`
@@ -67,6 +72,19 @@ type (
 		Genesis            Genesis  `yaml:"genesis"`
 	}
 )
+
+// String masks the DB password so accidentally logging the config (e.g.
+// main.go's startup `loaded config: %+v` line) doesn't leak the plaintext
+// credential into container stdout. The alias type prevents infinite
+// recursion — fmt won't call String on the alias since it has no method set.
+func (d Database) String() string {
+	type alias Database
+	cp := alias(d)
+	if cp.Password != "" {
+		cp.Password = "***"
+	}
+	return fmt.Sprintf("%+v", cp)
+}
 
 func New(path string) (cfg *Config, err error) {
 	body, err := ioutil.ReadFile(path)

--- a/main.go
+++ b/main.go
@@ -59,7 +59,9 @@ func main() {
 		log.Fatalf("failed to connect DB, %v", err)
 	}
 	log.Printf("connected to DB")
-	if err := db2.AutoMigrate(&model.HermesDropRecords{}); err != nil {
+	if config.Default.Database.SkipAutoMigrate {
+		log.Printf("skipping AutoMigrate (database.skipAutoMigrate=true)")
+	} else if err := db2.AutoMigrate(&model.HermesDropRecords{}); err != nil {
 		log.Fatalf("failed to migrate DB, %v", err)
 	}
 	if err := chainrpc.Init(config.Default.RPC); err != nil {


### PR DESCRIPTION
## Why

While deploying analyser-api against a read-only PG streaming standby (cross-DC DR setup), two problems surfaced:

### 1. Plaintext DB password in startup log

main.go line 56:
\`\`\`go
log.Printf(\"loaded config: %+v\", config.Default)
\`\`\`

This prints the full Database struct including the plaintext password on every startup. Anyone with \`docker logs analyser-api\` access can read it. Verified live — the password I rotated this morning came out of a routine \`docker logs\` invocation.

### 2. AutoMigrate breaks on read-only standby

main.go line 62:
\`\`\`go
if err := db2.AutoMigrate(&model.HermesDropRecords{}); err != nil {
    log.Fatalf(\"failed to migrate DB, %v\", err)
}
\`\`\`

AutoMigrate issues DDL on every startup. A PG streaming standby rejects writes:
\`\`\`
failed to migrate DB, ERROR: cannot execute ALTER TABLE in a read-only transaction (SQLSTATE 25006)
\`\`\`
→ crash-loop. There is currently no way to opt out short of patching the binary.

## What changes

**Fix 1 — password redaction.** Added \`Database.String()\` that masks \`Password\` with \`***\`. Go's \`fmt\` recurses into struct fields and uses the field type's \`Stringer\` when one exists, so \`%+v\` on \`Config\` now prints e.g.:

\`\`\`
{Server:{...} Database:{Driver:postgres ... Password:*** Name:mainnet Debug:false SkipAutoMigrate:false} RPC:... }
\`\`\`

The \`type alias Database\` trick prevents infinite recursion (the alias type doesn't inherit the method set).

**Fix 2 — SkipAutoMigrate flag.** Added \`Database.SkipAutoMigrate\` (\`yaml:\"skipAutoMigrate\"\` / \`env:\"DB_SKIP_AUTO_MIGRATE\"\`). When true, main.go logs \"skipping AutoMigrate\" and proceeds. Default \`false\` preserves existing behaviour for primary deployments.

## Verified

- \`go build ./...\` clean
- \`go vet ./...\` clean
- Smoke-test program that constructs a \`Config\`, sets a known-distinct plaintext password, formats with \`%+v\`, and asserts: (a) plaintext absent, (b) \`Password:***\` present, (c) \`SkipAutoMigrate:true\` field visible. Passes.

## Out of scope / follow-up

- A separate operational hardening that should follow: redact in \`Debug=true\` GORM SQL logs too. Not done here — GORM's logger surface is different and warrants its own PR.
- Existing \`io/ioutil\` deprecation warnings in this file are pre-existing and left untouched.