### PR TITLE
feat: add /healthz HTTP endpoint for LB probes

### DIFF
--- a/apiservice/apiserver.go
+++ b/apiservice/apiserver.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"text/template"
+	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
@@ -18,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-analyser-api/api"
 	"github.com/iotexproject/iotex-analyser-api/auth"
 	"github.com/iotexproject/iotex-analyser-api/config"
+	"github.com/iotexproject/iotex-analyser-api/db"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	graphqlruntime "github.com/ysugimoto/grpc-graphql-gateway/runtime"
 	"google.golang.org/grpc"
@@ -203,9 +205,33 @@ func StartGRPCProxyService(templates embed.FS) error {
 		log.Fatal(err)
 	}
 	http.Handle("/docs/", instrument("docs", http.StripPrefix("/docs/", http.FileServer(http.FS(fsys)))))
+	http.HandleFunc("/healthz", healthzHandler)
 	http.Handle("/", instrument("api", auth.JWTTokenMiddleware(auth.CheckWhiteListMiddleware(gwmux))))
 	http.Handle("/metrics", promhttp.Handler())
 
 	port := fmt.Sprintf(":%d", config.Default.Server.HTTPAPIPort)
 	return http.ListenAndServe(port, nil)
+}
+
+// healthzHandler is an unauthenticated LB probe: pings the DB and returns 200/503.
+// No Prometheus instrumentation so high-frequency probes don't pollute /metrics.
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	gdb := db.DB()
+	if gdb == nil {
+		http.Error(w, "db not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		http.Error(w, "db unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+	if err := sqlDB.PingContext(ctx); err != nil {
+		http.Error(w, "db ping failed", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
 }


### PR DESCRIPTION
## Summary

Adds a plain unauthenticated `/healthz` HTTP endpoint that an external load balancer (Cloudflare LB, k8s, nginx upstream check, etc.) can hit to decide whether an `analyser-api` replica is fit to serve.

The check does a DB ping with a 2-second deadline:
- **200 `ok`** — GORM initialized and underlying `*sql.DB` ping succeeds
- **503** + short reason — pool not initialized, driver returns an error, or ping fails

## Why

The HTTP gateway on `:8889` currently has no unauthenticated, dependency-aware probe. `/metrics` exists but says nothing about DB reachability, and every business route goes through JWT auth. The gRPC server on `:8888` already serves the standard `grpc.health.v1.Health/Check` (static SERVING), so this fills the symmetric gap on the HTTP side and makes a probe actually mean "I can serve a query."

Use case driving this: passive DR between the bm5 primary and bm3 standby — when we eventually move to CF Load Balancing for active-active, CF needs an HTTP health URL that returns 200 only when the backend can really answer.

## Implementation notes

- Registered on the default `http.ServeMux` as `/healthz`, ahead of the catch-all `/` that runs through `auth.JWTTokenMiddleware` — so the probe is auth-free without touching the whitelist.
- Not wrapped in `instrument(...)` so high-frequency probes don't pollute the Prometheus histogram for application traffic.
- 2s timeout on `PingContext` — long enough to survive a hiccup, short enough not to queue behind a stuck connection.

## Test plan

- [x] `go build ./...`
- [ ] Probe locally: `curl -i http://127.0.0.1:8889/healthz` → `200 ok`
- [ ] Stop the DB → `curl -i http://127.0.0.1:8889/healthz` → `503`
- [ ] Confirm no JWT prompt / no `/metrics` histogram entry for `/healthz`