### PR TITLE
perf(actions): rewrite GetXrc20InfoByAddress as UNION to use composite indexes

### DIFF
--- a/common/actions/xrc20.go
+++ b/common/actions/xrc20.go
@@ -26,11 +26,24 @@ func GetXrc20CountByAddress(address string) (int64, error) {
 	return count, nil
 }
 
+// `OR ... ORDER BY id DESC LIMIT N` on erc20_transfers makes the planner pick
+// a backward pkey scan (~120s on a 220M-row table for addresses that match
+// late). Split into two index scans + UNION so each leg uses its own
+// (sender|recipient, id DESC) composite index. Inner LIMIT must be skip+first
+// for deep pages to be correct; UNION (not UNION ALL) drops the self-transfer
+// duplicate by id.
 func GetXrc20InfoByAddress(address string, skip, first uint64) ([]*XrcInfo, error) {
 	var lists []*XrcInfo
 	db := db.DB()
-	query := "select t1.action_hash,t1.sender,t1.recipient,t1.amount,t1.block_height,t1.timestamp,t1.contract_address from erc20_transfers t1 where (sender=? or recipient=?) order by t1.id desc limit ? offset ?"
-	if err := db.Raw(query, address, address, first, skip).Scan(&lists).Error; err != nil {
+	inner := skip + first
+	query := `SELECT t.action_hash, t.sender, t.recipient, t.amount, t.block_height, t.timestamp, t.contract_address FROM (
+		(SELECT id, action_hash, sender, recipient, amount, block_height, timestamp, contract_address
+		 FROM erc20_transfers WHERE sender=? ORDER BY id DESC LIMIT ?)
+		UNION
+		(SELECT id, action_hash, sender, recipient, amount, block_height, timestamp, contract_address
+		 FROM erc20_transfers WHERE recipient=? ORDER BY id DESC LIMIT ?)
+	) t ORDER BY t.id DESC LIMIT ? OFFSET ?`
+	if err := db.Raw(query, address, inner, address, inner, first, skip).Scan(&lists).Error; err != nil {
 		return nil, err
 	}
 	return lists, nil


### PR DESCRIPTION
## Summary

- Rewrites the `WHERE sender=? OR recipient=?` query on `erc20_transfers` in `common/actions/xrc20.go` to a `UNION` over per-leg index scans
- Lets the planner use the `(sender, id DESC)` / `(recipient, id DESC)` composite indexes that already exist on bm5 (PG17 analyser primary)
- No API/protocol/schema change; only the SQL inside two helper funcs is rewritten

## Problem

On bm5 the original query takes **120+ seconds** for accounts that touch ERC20 transfers infrequently. The `EXPLAIN ANALYZE` shows the planner falling back to a backward primary-key scan because the OR predicate disqualifies both single-column and composite indexes:

```
 Limit  (cost=0.57..1958.73 rows=1) (actual time=123945.954..123945.955 rows=1)
   ->  Index Scan Backward using erc20_transfers_pkey on erc20_transfers
         Filter: ((sender)::text = '...') OR ((recipient)::text = '...')
         Rows Removed by Filter: 221,806,318
 Execution Time: 123,945 ms
```

Cost estimate `1958.73` vs reality `123,945 ms` — the planner mis-estimates by ~60,000×.

This fires `PostgresLongRunningQuery` (`pg_stat_activity_max_tx_duration > 300s`) on the iotex monitoring stack roughly daily.

## Fix

Split the OR into two index scans joined by `UNION`:

- **`GetXrc20InfoByAddress`** — each leg pulls `(skip+first)` rows via its composite index, outer `ORDER BY id DESC LIMIT first OFFSET skip` picks the final page. `UNION` (not `UNION ALL`) deduplicates the self-transfer overlap by `id`.
- **`GetXrc20CountByAddress`** — `|A ∪ B| = |A| + |B| - |A ∩ B|`. Each leg is an index-only count on a single column.

## Measured (bm5, PG17, 220M rows)

| Query                       | Plan                                       | Execution |
|-----------------------------|--------------------------------------------|-----------|
| Before (`OR`)               | `Index Scan Backward using ..._pkey`       | **123,945 ms** |
| After (`UNION`)             | `Merge Append` over both composite indexes | **1.179 ms**  |

≈100,000× speedup. The composite indexes `erc20_transfers_sender_id_idx` and `erc20_transfers_recipient_id_idx` are already built (`CREATE INDEX CONCURRENTLY`, ~9 min build) on bm5 primary and replicated to bm3 standby.

## Notes

- Same `XrcInfo` shape returned; column order/types unchanged
- Two callers exercised: `XRC20Service.XRC20ByAddress` (gRPC + GraphQL + REST) and `ActionService.GetXrc20ByAddress` (legacy)
- Single-column `idx_erc20_transfers_sender` / `idx_erc20_transfers_recipient` can be dropped post-deploy if disk pressure justifies — out of scope here

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go vet ./common/actions/...` clean (verified locally)
- [ ] Deploy to a non-prod analyser-api pointing at bm5; hit `XRC20ByAddress` for an active address and a cold address; verify same rows and same `count` as before
- [ ] Verify `pg_stat_activity` no longer shows multi-minute queries on `erc20_transfers` after rollout